### PR TITLE
Add reset ("copy") interface, and enforce python3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,15 @@ for a in [False, True]:
 		for c in [1, 2, 3]:
 			....
 ```
+
+Additionally, an option loop (or combination thereof) can be reset using the copy
+interface:
+
+```python
+d1 = {'lang' : ['c'], 'doThingX' : [True, False]}
+oploop1 = optionloop(d1)
+
+# iterate through 1
+
+oploop2 = oploop1.copy()
+```

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   build:
     - python >=2.7,<3|>=3.5,{{PY_VER}}*
     - setuptools
+    - six
 
   run:
     - python {{PY_VER}}*

--- a/optionloop/_version.py
+++ b/optionloop/_version.py
@@ -1,4 +1,4 @@
-__version_info__ = (1, 0, 5, '')
+__version_info__ = (1, 0, 6, '')
 __version__ = '.'.join(map(str, __version_info__[:3]))
 if len(__version_info__) == 4:
     __version__ += __version_info__[-1]

--- a/optionloop/optionloop.py
+++ b/optionloop/optionloop.py
@@ -181,7 +181,7 @@ class OptionLoop(object):
         startlen = 1
         if self.index < self.end_index:
             for key, value in six.iteritems(self.mydict):
-                value_list[key] = value[(self.index / startlen) % len(value)]
+                value_list[key] = value[int(self.index / startlen) % len(value)]
                 startlen *= len(value)
 
             self.index += 1

--- a/optionloop/optionloop.py
+++ b/optionloop/optionloop.py
@@ -81,6 +81,7 @@ for a in [False, True]:
 """
 
 from collections import defaultdict
+import six
 
 
 class OptionLoop(object):
@@ -149,7 +150,7 @@ class OptionLoop(object):
         self.mydict = initializing_dictionary.copy()
         self.index = 0
         self.end_index = None
-        for key, value in self.mydict.items():
+        for key, value in six.iteritems(self.mydict):
             if isinstance(value, (str, bytes)):
                 self.mydict[key] = [value]
                 size = 1
@@ -179,7 +180,7 @@ class OptionLoop(object):
             value_list = {}
         startlen = 1
         if self.index < self.end_index:
-            for key, value in self.mydict.iteritems():
+            for key, value in six.iteritems(self.mydict):
                 value_list[key] = value[(self.index / startlen) % len(value)]
                 startlen *= len(value)
 

--- a/optionloop/optionloop.py
+++ b/optionloop/optionloop.py
@@ -179,7 +179,7 @@ class OptionLoop(object):
         else:
             value_list = {}
         startlen = 1
-        if self.index < self.end_index:
+        if self.end_index is not None and self.index < self.end_index:
             for key, value in six.iteritems(self.mydict):
                 value_list[key] = value[int(self.index / startlen) % len(value)]
                 startlen *= len(value)

--- a/optionloop/optionloop.py
+++ b/optionloop/optionloop.py
@@ -149,7 +149,7 @@ class OptionLoop(object):
         self.mydict = initializing_dictionary.copy()
         self.index = 0
         self.end_index = None
-        for key, value in self.mydict.iteritems():
+        for key, value in self.mydict.items():
             if isinstance(value, (str, bytes)):
                 self.mydict[key] = [value]
                 size = 1

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,10 @@ except (ImportError, OSError, IOError):
     print('Warning: pypandoc module not found, could not convert Markdown to RST')
     long_description = desc
 
+install_require = [
+    'six'
+]
+
 tests_require = [
     'nose',
 ]
@@ -37,6 +41,7 @@ setup(
     packages=['optionloop', 'optionloop.tests'],
     zip_safe=True,
     test_suite='nose.collector',
+    install_require=install_require,
     tests_require=tests_require,
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except (ImportError, OSError, IOError):
     print('Warning: pypandoc module not found, could not convert Markdown to RST')
     long_description = desc
 
-install_require = [
+install_requires = [
     'six'
 ]
 
@@ -41,7 +41,7 @@ setup(
     packages=['optionloop', 'optionloop.tests'],
     zip_safe=True,
     test_suite='nose.collector',
-    install_require=install_require,
+    install_requires=install_requires,
     tests_require=tests_require,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Added a "copy" interface to reset the optionloop back to it's original state.

Additionally, fix some python3 things that I unwittingly broke (hooray me!)